### PR TITLE
Integrate support for UML diagram generation

### DIFF
--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -12,11 +12,36 @@
 apply from: '../build.common.gradle'
 apply from: '../build.dependencies.gradle'
 
+configurations {
+    umlDoclet
+}
+
 android {
     namespace = 'org.firstinspires.ftc.teamcode'
 
     packagingOptions {
         jniLibs.useLegacyPackaging true
+    }
+
+    /* AHHHHHHHHH */
+    afterEvaluate {
+        android.applicationVariants.each { variant ->
+           project.tasks.register('generate' + variant.name.capitalize() + 'Javadoc', Javadoc) {
+                group = "TeamcodeDoc"
+                description = "Generate documentation for Teamcode ($variant.name)."
+
+                source = android.sourceSets.main.java.srcDirs
+                classpath += variant.javaCompileProvider.get().classpath
+                classpath += files(variant.javaCompileProvider.get().destinationDirectory)
+
+                if (project.hasProperty("generateUML")) {
+                    options.docletpath = configurations.umlDoclet.files as List
+                    options.doclet = "nl.talsmasoftware.umldoclet.UMLDoclet"
+                } else {
+                    logger.info('Use -PgenerateUML to generate UML diagrams.')
+                }
+            }
+        }
     }
 }
 
@@ -24,6 +49,7 @@ dependencies {
     implementation project(':FtcRobotController')
     annotationProcessor files('lib/OpModeAnnotationProcessor.jar')
 
+    umlDoclet "nl.talsmasoftware:umldoclet:2.1.0"
     implementation 'com.acmerobotics.roadrunner:core:0.5.5'
     implementation 'com.acmerobotics.dashboard:dashboard:0.4.12'
     implementation 'org.openftc:easyopencv:1.7.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Allow Gradle to use up to 1 GB of RAM
-org.gradle.jvmargs=-Xmx1024M
+org.gradle.jvmargs=-Xmx2048M


### PR DESCRIPTION
Integrate support for UML diagram generation. I'll add documentation on how to produce this stuff later, but here's the gist:

1. Run the `generate<variant>Javadoc` task via Gradle.
2. Supply the `generateUML` property to generate the UML diagrams (requires Graphviz installation).

The diagrams are generated with [umldoclet](https://github.com/talsma-ict/umldoclet/).