### PR TITLE
Integrate Java documentation into GitHub Pages

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,8 +1,9 @@
 name: Deploy Javadocs to GitHub Pages
 
-# Generate and deploy on push and request.
+# Keep up to date with master, not a branch.
 on:
   push:
+    branches: [master]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -19,7 +20,7 @@ concurrency:
 # Jobs
 jobs:
   # Generate the docs.
-  document:
+  deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,13 +1,25 @@
 name: Deploy Javadocs to GitHub Pages
 
+# Generate and deploy on push and request.
 on:
   push:
-    branches:
-      - main
-      - milo-ghp-javadoc
+  workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+# Jobs
 jobs:
-  deploy:
+  # Generate the docs.
+  document:
     runs-on: ubuntu-latest
 
     steps:
@@ -26,8 +38,15 @@ jobs:
       - name: Build and generate Javadocs
         run: ./gradlew generateDebugJavadoc -PgenerateUML --no-daemon
 
+  # Deploy the docs.
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: document
+    steps:
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: actions/upload-pages-artifact@v1
         with:
-          publish_dir: ./TeamCode/build/docs/javadoc/
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          path: './TeamCode/build/docs/javadoc/'

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -38,14 +38,6 @@ jobs:
       - name: Build and generate Javadocs
         run: ./gradlew generateDebugJavadoc -PgenerateUML --no-daemon
 
-  # Deploy the docs.
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: document
-    steps:
       - name: Deploy to GitHub Pages
         uses: actions/upload-pages-artifact@v1
         with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -20,8 +20,10 @@ concurrency:
 jobs:
   # Generate the docs.
   document:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -42,3 +44,7 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: './TeamCode/build/docs/javadoc/'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
See #12, but this actually uploads to GitHub pages! This workflow is better than the previous one, because it actually works. Think of it like the person in the GIF below.

<img src="https://www.startpage.com/av/proxy-image?piurl=https%3A%2F%2Fmedia1.tenor.com%2Fimages%2Fd807ce97c55254cd2324fb457e6a3576%2Ftenor.gif%3Fitemid%3D4248312&sp=1695608365Taf7f43303be99f64d4f6ee4aef7f3f0bc4f0fc21da56be6a700be93a510cddb2">