### PR TITLE
Implement simple state machine controller

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/auton/StateMachineTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/auton/StateMachineTest.java
@@ -1,0 +1,51 @@
+package org.firstinspires.ftc.teamcode.auton;
+
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+
+import org.firstinspires.ftc.teamcode.subsystems.fsm.Edge;
+import org.firstinspires.ftc.teamcode.subsystems.fsm.State;
+import org.firstinspires.ftc.teamcode.subsystems.fsm.StateMachine;
+
+/**
+ * Autonomous OpMode to test the FSM subsystem.
+ */
+@Autonomous(name = "Subsystem test", group = "Testing OpModes")
+public class StateMachineTest extends LinearOpMode {
+    StateMachine stateMachine;
+
+    @Override
+    public void runOpMode() {
+        stateMachine.addState(new IdleState()).addState(new ForwardState());
+
+        while (opModeIsActive()) {
+            stateMachine.loop();
+        }
+    }
+}
+
+/**
+ * A state representing moving forward.
+ */
+class ForwardState implements State {
+    Edge<?>[] edges = new Edge[]{
+        new Edge<>(IdleState.class, (state) -> {
+            // You can replace this with any logic that, when it returns true, will switch
+            // the state machine over to IdleState.
+            return false;
+        })
+    };
+}
+
+/**
+ * A state representing idelation.
+ */
+class IdleState implements State {
+    Edge<?>[] edges = new Edge[]{
+            new Edge<>(ForwardState.class, (state) -> {
+                // You can replace this with any logic that, when it returns true, will switch
+                // the state machine over to ForwardState.
+                return false;
+            })
+    };
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/fsm/Edge.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/fsm/Edge.java
@@ -1,0 +1,38 @@
+package org.firstinspires.ftc.teamcode.subsystems.fsm;
+
+/** An edge in the state machine graph. */
+public class Edge<T> {
+    /**
+     * The state to transition to.
+     */
+    private final Class<T> to;
+
+    /**
+     * The callback that decides if the transition should occur.
+     */
+    private final EdgeCallback callback;
+
+    /** Constructs a new edge.
+     * @param to The state to transition to.
+     * @param callback The callback that decides if the transition should occur. */
+    public Edge(Class<T> to, EdgeCallback callback) {
+        this.to = to;
+        this.callback = callback;
+    }
+
+    /**
+     * Gets the name of the state to transition to.
+     * @return Returns the state to transition to.
+     */
+    public Class<T> getTo() {
+        return to;
+    }
+
+    /**
+     * Gets the callback that decides if the transition should occur.
+     * @return Returns the callback.
+     */
+    public EdgeCallback getCallback() {
+        return callback;
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/fsm/EdgeCallback.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/fsm/EdgeCallback.java
@@ -1,0 +1,14 @@
+package org.firstinspires.ftc.teamcode.subsystems.fsm;
+
+/**
+ * A callback to decide if a state machine should shift state.
+ */
+public interface EdgeCallback {
+    /**
+     * Ditto.
+     *
+     * @param state The state to evaluate with.
+     * @return Should we transition?
+     */
+    boolean valve(State state);
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/fsm/State.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/fsm/State.java
@@ -1,0 +1,34 @@
+package org.firstinspires.ftc.teamcode.subsystems.fsm;
+
+/**
+ * A state, belonging to an abstract state machine.
+ */
+public interface State {
+    /** The edges of the current state. */
+    Edge<?>[] edges = new Edge[0];
+
+    /**
+     * Runs ONCE during state machine initialization.
+     * <p>
+     * Sets up the robot physically, digitally, and mentally for the trials ahead.
+     */
+    default void init() {
+        /* Do nothin'. */
+    }
+
+    /**
+     * Runs ONCE when the state is very first reached. Very little initialization should be done
+     * here, if any.
+     */
+    default void start() {
+        /* Do nothin'. */
+    }
+
+    /**
+     * Code that is called once per frame if the state is active. Process input, send output to
+     * motors, etc. Do it all here!
+     */
+    default void loop() {
+        /* Do nothin'. */
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/fsm/StateMachine.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/fsm/StateMachine.java
@@ -1,0 +1,71 @@
+package org.firstinspires.ftc.teamcode.subsystems.fsm;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+/**
+ * Represents a finite state machine.
+ */
+public class StateMachine {
+    /* The flat list of states. The key is the state, the value is if it's been reached. */
+    private final HashMap<State, Boolean> states_reached = new HashMap<>();
+
+    /* The current state being executed. */
+    private State current = null;
+
+    /**
+     * Add a state to the state machine.
+     *
+     * @param state The state to add.
+     * @return The state machine.
+     */
+    public StateMachine addState(State state) {
+        current = current == null ? state : current;
+        states_reached.put(state, false);
+        state.init();
+        return this;
+    }
+
+    /**
+     * Remove a state from the state machine.
+     *
+     * @param state The state to remove.
+     * @return The state machine.
+     */
+    public StateMachine deleteState(State state) {
+        states_reached.remove(state);
+        return this;
+    }
+
+    /**
+     * Called on every frame of the robot, it ticks and manages the state machine.
+     */
+    public void loop() {
+        /* Sanity. */
+        if (states_reached.size() == 0) {
+            throw new RuntimeException("No states in state machine.");
+        }
+
+        /* Run start() once we reach the state. */
+        if (Boolean.FALSE.equals(states_reached.get(current))) {
+            current.start();
+            states_reached.put(current, true);
+        }
+
+        /* Run the current state's looping function. */
+        current.loop();
+
+        /*
+         * Figure out which, if any, state the current state wants to pass off execution to.
+         * Filter out all the closed valves, get all the states that the true valves point to,
+         * and set that to the current.
+         */
+        current = Arrays.stream(current.edges).filter(e -> e.getCallback().valve(current)).map((e) -> {
+            // TODO: Handle multiple true valves instead of blindly accepting the first.
+            return states_reached.keySet().stream().filter((s) -> {
+                //noinspection CodeBlock2Expr
+                return s.getClass().isInstance(e.getTo());
+            }).findFirst().orElseThrow(() -> new RuntimeException("Valve function referenced non-existent state '" + e.getTo() + "'."));
+        }).findFirst().orElseThrow(() -> new RuntimeException("State '" + current.getClass().getSimpleName() + "' has no children."));
+    }
+}


### PR DESCRIPTION
A simple state machine controller. Only 61 lines of actual code. Four source files, and one example file. One of the source files is literally 4 lines of code, the rest is comments (Java won't let you define an ad-hoc callback type). I think it's really pretty clean.

There's some functional stuff in there (i.e. `stream`s and `filter`s), and if you want I can remove it, but it makes it much easier to conceptualize in my opinion.

Check the Discord for the two versions, the simpler version is a bit more bug prone (it seems to me) but it doesn't make use of generics which you (@DragonDev07) might find appealing.

Resolves #6 

<img src="https://www.startpage.com/av/proxy-image?piurl=http%3A%2F%2Fwww.animated-gifs.fr%2Fcategory_graphics%2Fperfect-loops-machines%2F32184568.gif&sp=1695715691T6f3e9d0abc7a7738a0cea0540cf21831bdd50de57226fa9e16a7b56c2e6e9b3a">