### PR TITLE
Fix SMC equivalency bug, repair example

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/auton/StateMachineTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/auton/StateMachineTest.java
@@ -1,8 +1,10 @@
 package org.firstinspires.ftc.teamcode.auton;
 
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
-import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.eventloop.opmode.OpMode;
+import com.qualcomm.robotcore.hardware.Gamepad;
 
+import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.teamcode.subsystems.fsm.Edge;
 import org.firstinspires.ftc.teamcode.subsystems.fsm.State;
 import org.firstinspires.ftc.teamcode.subsystems.fsm.StateMachine;
@@ -10,17 +12,23 @@ import org.firstinspires.ftc.teamcode.subsystems.fsm.StateMachine;
 /**
  * Autonomous OpMode to test the FSM subsystem.
  */
-@Autonomous(name = "Subsystem test", group = "Testing OpModes")
-public class StateMachineTest extends LinearOpMode {
-    StateMachine stateMachine;
+@Autonomous(name = "State machine test", group = "Testing OpModes")
+public class StateMachineTest extends OpMode {
+    public static Telemetry pTelemetry;
+    public static Gamepad gamepad;
+    private final StateMachine stateMachine = new StateMachine();
 
     @Override
-    public void runOpMode() {
+    public void init() {
+        pTelemetry = telemetry;
+        gamepad = gamepad1;
         stateMachine.addState(new IdleState()).addState(new ForwardState());
+    }
 
-        while (opModeIsActive()) {
-            stateMachine.loop();
-        }
+    @Override
+    public void loop() {
+        stateMachine.loop();
+        telemetry.update();
     }
 }
 
@@ -28,24 +36,36 @@ public class StateMachineTest extends LinearOpMode {
  * A state representing moving forward.
  */
 class ForwardState implements State {
-    Edge<?>[] edges = new Edge[]{
-        new Edge<>(IdleState.class, (state) -> {
-            // You can replace this with any logic that, when it returns true, will switch
-            // the state machine over to IdleState.
-            return false;
-        })
-    };
+    @Override
+    public Edge<?>[] getEdges() {
+        return new Edge[]{
+                new Edge<>(IdleState.class, (state) -> StateMachineTest.gamepad.a)
+        };
+    }
+
+    @Override
+    public void loop() {
+        StateMachineTest.pTelemetry.addData("state", "ForwardState");
+        StateMachineTest.pTelemetry.addData("buttonA", StateMachineTest.gamepad.a);
+        StateMachineTest.pTelemetry.addData("buttonB", StateMachineTest.gamepad.b);
+    }
 }
 
 /**
  * A state representing idelation.
  */
 class IdleState implements State {
-    Edge<?>[] edges = new Edge[]{
-            new Edge<>(ForwardState.class, (state) -> {
-                // You can replace this with any logic that, when it returns true, will switch
-                // the state machine over to ForwardState.
-                return false;
-            })
-    };
+    @Override
+    public Edge<?>[] getEdges() {
+        return new Edge[]{
+                new Edge<>(ForwardState.class, (state) -> StateMachineTest.gamepad.b)
+        };
+    }
+
+    @Override
+    public void loop() {
+        StateMachineTest.pTelemetry.addData("state", "IdleState");
+        StateMachineTest.pTelemetry.addData("buttonA", StateMachineTest.gamepad.a);
+        StateMachineTest.pTelemetry.addData("buttonB", StateMachineTest.gamepad.b);
+    }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/fsm/State.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/fsm/State.java
@@ -5,7 +5,7 @@ package org.firstinspires.ftc.teamcode.subsystems.fsm;
  */
 public interface State {
     /** The edges of the current state. */
-    Edge<?>[] edges = new Edge[0];
+    Edge<?>[] getEdges();
 
     /**
      * Runs ONCE during state machine initialization.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/fsm/StateMachine.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/fsm/StateMachine.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.subsystems.fsm;
 
-import java.util.Arrays;
 import java.util.HashMap;
 
 /**
@@ -55,17 +54,22 @@ public class StateMachine {
         /* Run the current state's looping function. */
         current.loop();
 
-        /*
-         * Figure out which, if any, state the current state wants to pass off execution to.
-         * Filter out all the closed valves, get all the states that the true valves point to,
-         * and set that to the current.
-         */
-        current = Arrays.stream(current.edges).filter(e -> e.getCallback().valve(current)).map((e) -> {
-            // TODO: Handle multiple true valves instead of blindly accepting the first.
-            return states_reached.keySet().stream().filter((s) -> {
-                //noinspection CodeBlock2Expr
-                return s.getClass().isInstance(e.getTo());
-            }).findFirst().orElseThrow(() -> new RuntimeException("Valve function referenced non-existent state '" + e.getTo() + "'."));
-        }).findFirst().orElseThrow(() -> new RuntimeException("State '" + current.getClass().getSimpleName() + "' has no children."));
+        /* Current state state switching logic. */
+        for (Edge<?> edge : current.getEdges()) {
+            if (edge.getCallback().valve(current)) {
+                boolean stateFound = false;
+                for (State state : states_reached.keySet()) {
+                    if (state.getClass() == edge.getTo()) {
+                        current = state;
+                        stateFound = true;
+                        break;
+                    }
+                }
+
+                if (!stateFound) {
+                    throw new RuntimeException("Valve function referenced non-existent state '" + edge.getTo() + "'.");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
In the past, `State` switching was broken in some cases due to an equivalency bug. To fix this, some API changes had to happen, so the example was updated as well. Nothing too complicated.

<img src="https://www.startpage.com/av/proxy-image?piurl=https%3A%2F%2Fmedia.giphy.com%2Fmedia%2F3orieSZhqmslIgWTlu%2Fgiphy.gif&sp=1695831399T7509689c4d592c0c53c7cd20fbdc01642a64da55fc41c2618e2ba196704966ff">